### PR TITLE
30autoproxy: update apt-transport-http syntax

### DIFF
--- a/30autoproxy
+++ b/30autoproxy
@@ -1,1 +1,1 @@
-Acquire::http::ProxyAutoDetect "/usr/share/squid-deb-proxy-client/apt-avahi-discover";
+Acquire::http::Proxy-Auto-Detect "/usr/share/squid-deb-proxy-client/apt-avahi-discover";


### PR DESCRIPTION
Fixes https://github.com/mvo5/squid-deb-proxy/issues/4 and [LP #1875110](https://bugs.launchpad.net/ubuntu/+source/squid-deb-proxy/+bug/1875110)