### PR TITLE
d/squid-deb-proxy.postinst: add launchpadcontent

### DIFF
--- a/debian/squid-deb-proxy.postinst
+++ b/debian/squid-deb-proxy.postinst
@@ -51,7 +51,9 @@ EOF
 
 # launchpad personal package archives (disabled by default)
 #ppa.launchpad.net
+#ppa.launchpadcontent.net
 #private-ppa.launchpad.net
+#private-ppa.launchpadcontent.net
 
 # add additional mirror domains here (disabled by default)
 #linux.dropbox.com
@@ -86,6 +88,7 @@ EOF
 #   sudo dpkg-reconfigure -plow squid-deb-proxy
 # to change
 ppa.launchpad.net
+ppa.launchpadcontent.net
 EOF
                 ;;
             *)


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/ubuntu/+source/squid-deb-proxy/+bug/1963590

Patch comes from @alexmurray. Please see Launchpad Bug.