### PR TITLE
apt-avahi-discover: handle exceptions when connecting to proxies

### DIFF
--- a/apt-avahi-discover
+++ b/apt-avahi-discover
@@ -47,11 +47,14 @@ class AptAvahiClient:
         self.address = addr
 
     async def time_connect(self):
-        _time_init = time.time()
-        reader, writer = await asyncio.open_connection(
-            self.address[0], self.address[1])
-        self.time_to_connect = time.time() - _time_init
-        writer.close()
+        try:
+            _time_init = time.time()
+            reader, writer = await asyncio.open_connection(
+                self.address[0], self.address[1])
+            self.time_to_connect = time.time() - _time_init
+            writer.close()
+        except Exception:
+            pass
 
     def __eq__(self, other):
         return self.time_to_connect == other.time_to_connect


### PR DESCRIPTION
Trap exceptions while attempting to connect to each discovered proxy to determine which is the fastest. This resolves the [regression](https://bugs.launchpad.net/ubuntu/+source/squid-deb-proxy/+bug/2002562) introduced with the port to asyncio which occurs when Avahi reports a proxy which refuses incoming connections, for example because the server has been shut down.