### PR TITLE
Update debian metadata

### DIFF
--- a/debian/apparmor-profiles/squid-deb-proxy
+++ b/debian/apparmor-profiles/squid-deb-proxy
@@ -1,0 +1,6 @@
+# vim:syntax=apparmor
+
+    /etc/squid-deb-proxy/** r,
+    /var/log/squid-deb-proxy/* rw,
+    /run/squid-deb-proxy.pid rwk,
+    /var/cache/squid-deb-proxy/** rw,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+squid-deb-proxy (0.8.15+nmu1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Add apparmor profiles to work (Closes: #932501)
+
+ -- Hideki Yamane <henrich@debian.org>  Mon, 14 Jun 2021 23:41:11 +0900
+
 squid-deb-proxy (0.8.15) unstable; urgency=medium
 
   [ Graham Cantin ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ squid-deb-proxy (0.8.16) UNRELEASED; urgency=medium
 
   [ Mika Pflüger ]
   * Merged NMU changes, thanks to Hideki
-  * debian/control: update VCS and homepage metadata
+  * debian/control: update VCS and homepage metadata (Closes: #999647)
 
  -- Mika Pflüger <debian@mikapflueger.de>  Fri, 14 Apr 2023 23:26:56 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+squid-deb-proxy (0.8.16) UNRELEASED; urgency=medium
+
+  [ Mika Pflüger ]
+  * Merged NMU changes, thanks to Hideki
+  * debian/control: update VCS and homepage metadata
+
+ -- Mika Pflüger <debian@mikapflueger.de>  Fri, 14 Apr 2023 23:26:56 +0200
+
 squid-deb-proxy (0.8.15+nmu1) unstable; urgency=medium
 
   * Non-maintainer upload.

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,9 @@ Build-Depends: debhelper (>= 12),
                po-debconf,
                flake8
 Standards-Version: 4.4.0
-Vcs-Bzr: https://code.launchpad.net/~squid-deb-proxy-developers/squid-deb-proxy/trunk
-Homepage: https://launchpad.net/squid-deb-proxy
+Vcs-Browser: https://github.com/mvo5/squid-deb-proxy
+Vcs-Git: https://github.com/mvo5/squid-deb-proxy.git
+Homepage: https://github.com/mvo5/squid-deb-proxy
 
 Package: squid-deb-proxy
 Architecture: all
@@ -39,7 +40,7 @@ Description: automatic proxy discovery for APT based on Avahi
  that publishes the service as _apt_proxy._tcp.
 
 Package: squid-deb-proxy-client-udeb
-XC-Package-Type: udeb
+Package-Type: udeb
 Section: debian-installer
 Architecture: all
 Depends: configured-network,

--- a/debian/squid-deb-proxy.dirs
+++ b/debian/squid-deb-proxy.dirs
@@ -1,2 +1,3 @@
 etc/resolvconf/update-libc.d
+etc/apparmor.d/abstractions/squid-deb-proxy
 var/log/squid-deb-proxy

--- a/debian/squid-deb-proxy.install
+++ b/debian/squid-deb-proxy.install
@@ -1,3 +1,4 @@
 ../update-libc.d etc/resolvconf/
 etc/squid-deb-proxy
 init-common.sh usr/share/squid-deb-proxy/
+../apparmor-profiles/* etc/apparmor.d/abstractions/squid-deb-proxy/


### PR DESCRIPTION
# Update debian metadata

* `debian/control` point to GitHub for VCS and Homepage fields
* `debian/control` use standard Package-Type field name
* `debian/changelog` add new version, acknowledge NMU

# context 

Builds on https://github.com/mvo5/squid-deb-proxy/pull/10 because otherwise there would be merge conflicts in `debian/changelog`. I hope to find some more time to work on the open bugs in the BTS, tell me if you prefer individual PRs or one big PR or something else.